### PR TITLE
Fix crashing and slider title positions

### DIFF
--- a/Bean Juice/Views/Views/Components/CoffeeRatioSlider.swift
+++ b/Bean Juice/Views/Views/Components/CoffeeRatioSlider.swift
@@ -14,13 +14,13 @@ struct CoffeeRatioSlider: View {
     @EnvironmentObject var settings: SettingsViewModel
 
     var body: some View {
-        Text("Ratio")
-            .font(.headline)
+        Text("1:\(Int(ratio))")
+            .font(.subheadline)
             .padding(.bottom, -5)
         Slider(value: $ratio, in: 8...20, step: 1)
             .accentColor(settings.getAccentColor())
-        Text("1:\(Int(ratio))")
-            .font(.subheadline)
+        Text("Ratio")
+            .font(.headline)
             .padding(.bottom, 10)
             .padding(.top, 0)
     }

--- a/Bean Juice/Views/Views/Components/WaterAmountSlider.swift
+++ b/Bean Juice/Views/Views/Components/WaterAmountSlider.swift
@@ -26,20 +26,20 @@ struct WaterAmountSlider: View {
             ? 1
             : Double(method.maxWaterAmount / settings.selectedCupMlSize)
         if method.name == .frenchPress {
-            Text("Size")
-                .font(.headline)
+            Text("\(sizes[Int(selectedSize)]) ml")
+                .font(.subheadline)
                 .padding(.bottom, -5)
             Slider(
                 value: $selectedSize,
                 in: 0...Double(sizes.count - 1), step: 1
             ).accentColor(settings.getAccentColor())
-            Text("\(sizes[Int(selectedSize)]) ml")
-                .font(.subheadline)
+            Text("Size")
+                .font(.headline)
                 .padding(.bottom, -5)
                 .accessibility(identifier: "SizeValue")
         } else {
-            Text(settings.mlSelected ? "Water" : "Cups")
-                .font(.headline)
+            Text(settings.mlSelected ? "\(Int(waterAmount)) ml" : "\(Int(cups)) cups")
+                .font(.subheadline)
                 .padding(.bottom, -5)
             if settings.mlSelected {
                 Slider(
@@ -51,8 +51,8 @@ struct WaterAmountSlider: View {
                 Slider(value: $cups, in: 0...maxCups, step: 1).accentColor(settings.getAccentColor())
             }
         }
-        Text(settings.mlSelected ? "\(Int(waterAmount)) ml" : "\(Int(cups)) cups")
-            .font(.subheadline)
+        Text(settings.mlSelected ? "Water" : "Cups")
+            .font(.headline)
             .padding(.bottom, 10)
     }
 }

--- a/Bean Juice/Views/Views/Settings/SettingsView.swift
+++ b/Bean Juice/Views/Views/Settings/SettingsView.swift
@@ -28,7 +28,7 @@ struct SettingsView: View {
                     CupSelection()
                 }
 
-                HighlightColorSelection()
+                // HighlightColorSelection()
 
                 Section(header: Text("Have a great cafe in mind to add to the map?")) {
                     EmailCafeRecommendationsComponent()

--- a/Bean Juice/Views/Views/Settings/SettingsViewModel.swift
+++ b/Bean Juice/Views/Views/Settings/SettingsViewModel.swift
@@ -59,7 +59,7 @@ final class SettingsViewModel: ObservableObject {
     @AppStorage("accentColor") var accentColor: Color = .blue
 
     func getAccentColor() -> Color {
-        return accentColor
+        return .blue // accentColor
     }
 
     // MARK: ML selection


### PR DESCRIPTION
Disable custom color to prevent crashing.

Switch slider label positions for clarity when using sliders.